### PR TITLE
Don’t open multiple preference windows

### DIFF
--- a/PiHoleStats/Controllers/NavigationController.swift
+++ b/PiHoleStats/Controllers/NavigationController.swift
@@ -13,6 +13,8 @@ class NavigationController: ObservableObject {
     let preferences: UserPreferences
     let piholeDataProvider: PiholeDataProvider
     
+    lazy var preferencesController = PreferencesViewController(preferences: preferences, piholeListViewModel: PiholeListViewModel(piholeDataProvider: piholeDataProvider))
+    
     init(preferences: UserPreferences, piholeDataProvider: PiholeDataProvider) {
         self.preferences = preferences
         self.piholeDataProvider = piholeDataProvider
@@ -20,8 +22,7 @@ class NavigationController: ObservableObject {
     
     public func openPreferences() {
         NSApp.activate(ignoringOtherApps: true)
-        
-        let controller = PreferencesViewController(preferences: preferences, piholeListViewModel: PiholeListViewModel(piholeDataProvider: piholeDataProvider))
-        controller.show()
+
+        preferencesController.show()
     }
 }


### PR DESCRIPTION
Hi there! I just started using Pi Stats and I'm very happy with it. Thanks for making it! I found a few rough edges that I'm submitting PRs for. Not sure if you're interested in accepting outside contributions, or if you'll like my changes, but it never hurts to ask.

## This PR

In the current version of Pi Stats, clicking the "Preferences" button multiple times will open multiple preferences windows, one on top of the other. This PR changes the behavior such that there is no more than one open preferences window. If there is an existing preferences window, it gets brought to the front.